### PR TITLE
Remove cluster from activity stream (unused)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,6 @@ lazy val activityStreamImpl = project("activity-stream-impl")
   .enablePlugins(LagomJava)
   .settings(
     libraryDependencies ++= Seq(
-      lagomJavadslCluster,
       lagomJavadslTestKit
     )
   )


### PR DESCRIPTION
Remove `lagomJavadslCluster` from `activity-stream-impl` as it isn't used.