### PR TITLE
Update helm-charts repo URL

### DIFF
--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -74,7 +74,7 @@ The `reactive-sandbox` includes development-grade (i.e. it will lose your data) 
 
 ```bash
 helm init
-helm repo add lightbend-helm-charts https://lightbend.github.io/helm-charts
+helm repo add lightbend-helm-charts https://repo.lightbend.com/helm-charts
 helm update
 ```
 


### PR DESCRIPTION
We're moving the helm-charts repo.  While the old address will still work (probably for a long while yet), we'd like to update references to the new location.